### PR TITLE
YIMA-101-Categories-load-optimization

### DIFF
--- a/composables/services/admin/category.ts
+++ b/composables/services/admin/category.ts
@@ -3,10 +3,14 @@ import type { AsyncDataOptions } from '#app'
 import type { YimaFetchOptions } from '~/plugins/http'
 
 declare global {
-  interface AdminCategory {
+
+  interface Category {
     id: string
     name: string
-    children: AdminCategory[]
+    children: Category[]
+  }
+
+  interface AdminCategory extends Category {
     parent: string
   }
 }

--- a/server/api/admin/categories/[id]/index.delete.ts
+++ b/server/api/admin/categories/[id]/index.delete.ts
@@ -1,6 +1,7 @@
 import { where, documentId } from 'firebase/firestore'
 import { del, queryByCollection } from '~/server/lib/firestore'
 import { createYimaError } from '~/composables/services/admin/utils'
+import {ClientCategoryCache} from "~/server/lib/clientCategoryCache";
 
 export default defineEventHandler(async (event) => {
   const categoryId = event.context.params.id
@@ -20,6 +21,7 @@ export default defineEventHandler(async (event) => {
   }
 
   await del(categoryCollection, categoryId)
+  ClientCategoryCache.invalidateCustomerCategories();
 
   return {}
 })

--- a/server/api/admin/categories/[id]/index.put.ts
+++ b/server/api/admin/categories/[id]/index.put.ts
@@ -2,6 +2,7 @@ import { where, documentId } from 'firebase/firestore'
 import { queryByCollection, set } from '~/server/lib/firestore'
 import { createYimaError } from '~/composables/services/admin/utils'
 import { yimaReadBody } from '~/server/lib/utils'
+import {ClientCategoryCache} from "~/server/lib/clientCategoryCache";
 
 export default defineEventHandler(async (event) => {
   const categoryCollection = 'category'
@@ -22,7 +23,8 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  await set(categoryCollection, body, categoryId)
+  await set(categoryCollection, body, categoryId);
+  ClientCategoryCache.invalidateCustomerCategories();
 
   return {}
 })

--- a/server/api/admin/categories/index.post.ts
+++ b/server/api/admin/categories/index.post.ts
@@ -2,6 +2,7 @@ import { documentId, where } from 'firebase/firestore'
 import { createYimaError } from '~/composables/services/admin/utils'
 import { queryByCollection, set } from '~/server/lib/firestore'
 import { yimaReadBody } from '~/server/lib/utils'
+import {ClientCategoryCache} from "~/server/lib/clientCategoryCache";
 
 export default defineEventHandler(async (event) => {
   try {
@@ -21,6 +22,7 @@ export default defineEventHandler(async (event) => {
     }
 
     await set(categoryCollection, body, id)
+    ClientCategoryCache.invalidateCustomerCategories();
 
     return {}
   } catch (error: any) {

--- a/server/api/products/filters.get.ts
+++ b/server/api/products/filters.get.ts
@@ -1,10 +1,10 @@
-import { getCategories } from '~/server/lib/utils'
-import { client } from '~/server/lib/typesense'
+import {client} from '~/server/lib/typesense'
+import {ClientCategoryCache} from "~/server/lib/clientCategoryCache";
 
 export default defineEventHandler(async () => {
   const filters = []
 
-  const categoryItems = await getCategories(true)
+  const categoryItems = await ClientCategoryCache.getCustomerCategories()
   if (categoryItems.length > 0) {
     filters.push({ sectionName: 'categories', items: categoryItems })
   }

--- a/server/lib/clientCategoryCache.ts
+++ b/server/lib/clientCategoryCache.ts
@@ -1,0 +1,50 @@
+import {getCategories} from "~/server/lib/utils";
+
+const EXPIRE_MILLIS : number = 3 * 60 * 60 * 1000;
+export class ClientCategoryCache {
+  private readonly expirationTime: Date;
+  private expired: boolean;
+  private readonly categories: Category[];
+  private static instance: ClientCategoryCache;
+
+  constructor(categories : Category[]) {
+    this.categories = categories;
+    this.expirationTime = new Date(Date.now() + EXPIRE_MILLIS);
+    this.expired = false;
+  }
+
+  static getInstance = async (onExpireCategorySupplier: () => Promise<Category[]>) => {
+    if (!this.instance || this.instance.isExpired()) {
+      this.instance = new ClientCategoryCache(await onExpireCategorySupplier());
+    }
+    return this.instance;
+  }
+
+  public static getCustomerCategories = async () => {
+    const current = (await ClientCategoryCache
+      .getInstance(() => getCategories(true)))
+      .getCategories();
+    return [...current];
+  }
+
+  public static invalidateCustomerCategories () {
+    this.instance?.invalidate();
+  }
+
+  private isExpired(): boolean {
+    if (this.expired) {
+      return true;
+    }
+    this.expired = this.expirationTime < new Date();
+    return this.expired;
+  }
+
+  public getCategories() {
+    return this.categories;
+  }
+
+  protected invalidate() {
+    this.expired = true;
+  }
+
+}

--- a/server/lib/utils.ts
+++ b/server/lib/utils.ts
@@ -106,7 +106,7 @@ export const getCategories = async (client?: boolean) => {
 
   if (client) {
     return categories.map((category) => {
-      return { id: category.id, name: category.name, children: category.children }
+      return category as Category;
     })
   }
 


### PR DESCRIPTION
Add cache for data in plp filter component. 
For user, on categories request cache instantiated with specified lifetime (3 hours).
For admin, categories are still fetched on every request.
Changes in categories done by admin trigger cache invalidation.