### PR TITLE
Keep Filters Applied When Returning To The PLP

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -106,15 +106,16 @@ const currentPage = ref(Number(route.query.page) || 1)
 const itemsPerPage = ref(Number(route.query.itemsPerPage) || itemsPerPageOptionDefault)
 const filterString = ref(route.query.filter_by ?? '')
 
-const [{ data: products }, { data: filters }] = await Promise.all([
+const [{ data: filters }, { data: products }] = await Promise.all([
+  getProductFilters(),
   getProducts({
     params: {
       sort_by: currentSort.value || undefined,
       page: currentPage.value,
       per_page: itemsPerPage.value,
+      filter_by: filterString.value,
     },
   }),
-  getProductFilters(),
   // GetProducts({
   //   params: {
   //     filter_by: 'categories:[chosen-products]',

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -104,7 +104,7 @@ const productFiltersWrapper = ref()
 const currentSort = ref(route.query.sort_by ?? '')
 const currentPage = ref(Number(route.query.page) || 1)
 const itemsPerPage = ref(Number(route.query.itemsPerPage) || itemsPerPageOptionDefault)
-const filterString = ref(route.query.filter_by ?? '')
+const filterString = ref(route.query.filter_by ?? undefined)
 
 const [{ data: filters }, { data: products }] = await Promise.all([
   getProductFilters(),
@@ -129,6 +129,10 @@ const [{ data: filters }, { data: products }] = await Promise.all([
 ])
 
 function handleChangeFilters(resultString: string) {
+  if (filterString.value === resultString) {
+    return
+  }
+
   filterString.value = resultString
 
   setTimeout(async () => {


### PR DESCRIPTION
Now, when fetching filters from address line page won't be reset and customer will be moved to the position of the page he was on before clicking on product title.